### PR TITLE
Quitando imagen para db en dockercompose y cambiando puerto de la db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3.8'
 services:
   db:
     build: ./init-db
-    image: mysql:8.0.37-debian
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: rootpassword
@@ -13,7 +12,7 @@ services:
       MYSQL_CHARACTER_SET_SERVER: utf8mb4
       MYSQL_COLLATION_SERVER: utf8mb4_unicode_ci
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
       - db_data:/var/lib/mysql
       - ./init-db/my.cnf:/etc/mysql/my.cnf

--- a/init-db/init.sql
+++ b/init-db/init.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS cabins(
     imagen TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
 );
 
+
 CREATE TABLE IF NOT EXISTS habitaciones(
     id INT AUTO_INCREMENT PRIMARY KEY,
     cabin_id INT,

--- a/init-db/init.sql
+++ b/init-db/init.sql
@@ -1,5 +1,6 @@
 -- Configurar la base de datos para usar utf8mb4
 ALTER DATABASE hospedaje_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE hospedaje_db;
 
 CREATE TABLE IF NOT EXISTS cabins(
     id INT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
Quité la línea de imagen para db en el dockercompose porque es innecesaria ya que ya existe un parámetro para build y cambié el puerto de 3306 a 3307 para la db para evitar un paso extra al hacer el docker compose up